### PR TITLE
Use local futures dataset in CLOBDataSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,5 @@ cython_debug/
 #.idea/
 
 */*.DS_Store
-data/
+data/history/
+nexus/history/binance-futures/*.parquet

--- a/core/data_sources/clob.py
+++ b/core/data_sources/clob.py
@@ -2,8 +2,8 @@ import asyncio
 import logging
 import os
 import time
-from typing import Dict, List, Optional, Tuple, Any
 from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 from hummingbot.client.config.client_config_map import ClientConfigMap
@@ -21,38 +21,53 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 INTERVAL_MAPPING = {
-    '1s': 's',  # seconds
-    '1m': 'T',  # minutes
-    '3m': '3T',
-    '5m': '5T',
-    '15m': '15T',
-    '30m': '30T',
-    '1h': 'H',  # hours
-    '2h': '2H',
-    '4h': '4H',
-    '6h': '6H',
-    '12h': '12H',
-    '1d': 'D',  # days
-    '3d': '3D',
-    '1w': 'W'  # weeks
+    "1s": "s",  # seconds
+    "1m": "T",  # minutes
+    "3m": "3T",
+    "5m": "5T",
+    "15m": "15T",
+    "30m": "30T",
+    "1h": "H",  # hours
+    "2h": "2H",
+    "4h": "4H",
+    "6h": "6H",
+    "12h": "12H",
+    "1d": "D",  # days
+    "3d": "3D",
+    "1w": "W",  # weeks
 }
 
 
 class CLOBDataSource:
     CONNECTOR_TYPES = [ConnectorType.CLOB_SPOT, ConnectorType.CLOB_PERP, ConnectorType.Exchange, ConnectorType.Derivative]
-    EXCLUDED_CONNECTORS = ["vega_perpetual", "hyperliquid_perpetual", "dydx_perpetual", "cube", "ndax",
-                           "polkadex", "coinbase_advanced_trade", "kraken", "dydx_v4_perpetual", "hitbtc",
-                           "hyperliquid", "dexalot", "vertex"]
+    EXCLUDED_CONNECTORS = [
+        "vega_perpetual",
+        "hyperliquid_perpetual",
+        "dydx_perpetual",
+        "cube",
+        "ndax",
+        "polkadex",
+        "coinbase_advanced_trade",
+        "kraken",
+        "dydx_v4_perpetual",
+        "hitbtc",
+        "hyperliquid",
+        "dexalot",
+        "vertex",
+    ]
 
-    def __init__(self):
+    def __init__(self, local_data_path: Optional[str] = None):
         logger.info("Initializing ClobDataSource")
         self.candles_factory = CandlesFactory()
         self.trades_feeds = {"binance_perpetual": BinancePerpetualTradesFeed()}
         self.conn_settings = AllConnectorSettings.get_connector_settings()
-        self.connectors = {name: self.get_connector(name) for name, settings in self.conn_settings.items()
-                           if settings.type in self.CONNECTOR_TYPES and name not in self.EXCLUDED_CONNECTORS and
-                           "testnet" not in name}
+        self.connectors = {
+            name: self.get_connector(name)
+            for name, settings in self.conn_settings.items()
+            if settings.type in self.CONNECTOR_TYPES and name not in self.EXCLUDED_CONNECTORS and "testnet" not in name
+        }
         self._candles_cache: Dict[Tuple[str, str, str], pd.DataFrame] = {}
+        self.local_data_path = local_data_path
 
     @staticmethod
     def get_connector_config_map(connector_name: str):
@@ -61,31 +76,51 @@ class CLOBDataSource:
 
     @property
     def candles_cache(self):
-        return {key: Candles(candles_df=value, connector_name=key[0], trading_pair=key[1], interval=key[2])
-                for key, value in self._candles_cache.items()}
+        return {
+            key: Candles(candles_df=value, connector_name=key[0], trading_pair=key[1], interval=key[2])
+            for key, value in self._candles_cache.items()
+        }
 
-    def get_candles_from_cache(self,
-                               connector_name: str,
-                               trading_pair: str,
-                               interval: str):
+    def get_candles_from_cache(self, connector_name: str, trading_pair: str, interval: str):
         cache_key = (connector_name, trading_pair, interval)
         if cache_key in self._candles_cache:
             cached_df = self._candles_cache[cache_key]
 
-            return Candles(candles_df=cached_df, connector_name=connector_name,
-                           trading_pair=trading_pair, interval=interval)
+            return Candles(candles_df=cached_df, connector_name=connector_name, trading_pair=trading_pair, interval=interval)
         else:
             return None
 
+    def _load_local_dataset(self, connector_name: str, trading_pair: str, interval: str) -> Optional[pd.DataFrame]:
+        if not self.local_data_path:
+            return None
+        file_name = f"{trading_pair}_{interval}.parquet"
+        file_path = os.path.join(self.local_data_path, file_name)
+        if not os.path.exists(file_path):
+            return None
+        try:
+            candles = pd.read_parquet(file_path)
+            if "timestamp" not in candles.columns and "open_time" in candles.columns:
+                candles["timestamp"] = (candles["open_time"] // 1000).astype(int)
+            candles.rename(
+                columns={
+                    "quote_vol": "quote_asset_volume",
+                    "trade_count": "n_trades",
+                    "taker_base_vol": "taker_buy_base_volume",
+                    "taker_quote_vol": "taker_buy_quote_volume",
+                },
+                inplace=True,
+            )
+            candles.index = pd.to_datetime(candles["timestamp"], unit="s")
+            candles.index.name = None
+            self._candles_cache[(connector_name, trading_pair, interval)] = candles
+            return candles
+        except Exception as e:
+            logger.error(f"Error loading local dataset {file_path}: {e}")
+            return None
 
-
-    async def get_candles(self,
-                          connector_name: str,
-                          trading_pair: str,
-                          interval: str,
-                          start_time: int,
-                          end_time: int,
-                          from_trades: bool = False) -> Candles:
+    async def get_candles(
+        self, connector_name: str, trading_pair: str, interval: str, start_time: int, end_time: int, from_trades: bool = False
+    ) -> Candles:
         cache_key = (connector_name, trading_pair, interval)
 
         if cache_key in self._candles_cache:
@@ -94,11 +129,16 @@ class CLOBDataSource:
             cached_end_time = int(cached_df.index.max().timestamp())
 
             if cached_start_time <= start_time and cached_end_time >= end_time:
-                logger.info(
-                    f"Using cached data for {connector_name} {trading_pair} {interval} from {start_time} to {end_time}")
-                return Candles(candles_df=cached_df[(cached_df.index >= pd.to_datetime(start_time, unit='s')) &
-                                                    (cached_df.index <= pd.to_datetime(end_time, unit='s'))],
-                               connector_name=connector_name, trading_pair=trading_pair, interval=interval)
+                logger.info(f"Using cached data for {connector_name} {trading_pair} {interval} from {start_time} to {end_time}")
+                return Candles(
+                    candles_df=cached_df[
+                        (cached_df.index >= pd.to_datetime(start_time, unit="s"))
+                        & (cached_df.index <= pd.to_datetime(end_time, unit="s"))
+                    ],
+                    connector_name=connector_name,
+                    trading_pair=trading_pair,
+                    interval=interval,
+                )
             else:
                 if start_time < cached_start_time:
                     new_start_time = start_time
@@ -107,8 +147,34 @@ class CLOBDataSource:
                     new_start_time = cached_end_time + 1
                     new_end_time = end_time
         else:
-            new_start_time = start_time
-            new_end_time = end_time
+            local_df = self._load_local_dataset(connector_name, trading_pair, interval)
+            if local_df is not None:
+                cached_df = local_df
+                cached_start_time = int(cached_df.index.min().timestamp())
+                cached_end_time = int(cached_df.index.max().timestamp())
+                if cached_start_time <= start_time and cached_end_time >= end_time:
+                    logger.info(
+                        f"Using local data for {connector_name} {trading_pair} {interval} from {start_time} to {end_time}"
+                    )
+                    return Candles(
+                        candles_df=cached_df[
+                            (cached_df.index >= pd.to_datetime(start_time, unit="s"))
+                            & (cached_df.index <= pd.to_datetime(end_time, unit="s"))
+                        ],
+                        connector_name=connector_name,
+                        trading_pair=trading_pair,
+                        interval=interval,
+                    )
+                else:
+                    if start_time < cached_start_time:
+                        new_start_time = start_time
+                        new_end_time = cached_start_time - 1
+                    else:
+                        new_start_time = cached_end_time + 1
+                        new_end_time = end_time
+            else:
+                new_start_time = start_time
+                new_end_time = end_time
 
         try:
             logger.info(f"Fetching data for {connector_name} {trading_pair} {interval} from {new_start_time} to {new_end_time}")
@@ -119,49 +185,54 @@ class CLOBDataSource:
                 candles_df.columns = candles_df.columns.droplevel(0)
                 candles_df["timestamp"] = pd.to_numeric(candles_df.index) // 1e9
             else:
-                candle = self.candles_factory.get_candle(CandlesConfig(
-                    connector=connector_name,
-                    trading_pair=trading_pair,
-                    interval=interval
-                ))
-                candles_df = await candle.get_historical_candles(HistoricalCandlesConfig(
-                    connector_name=connector_name,
-                    trading_pair=trading_pair,
-                    start_time=new_start_time,
-                    end_time=new_end_time,
-                    interval=interval
-                ))
+                candle = self.candles_factory.get_candle(
+                    CandlesConfig(connector=connector_name, trading_pair=trading_pair, interval=interval)
+                )
+                candles_df = await candle.get_historical_candles(
+                    HistoricalCandlesConfig(
+                        connector_name=connector_name,
+                        trading_pair=trading_pair,
+                        start_time=new_start_time,
+                        end_time=new_end_time,
+                        interval=interval,
+                    )
+                )
                 if candles_df is None:
-                    return Candles(candles_df=pd.DataFrame(), connector_name=connector_name, trading_pair=trading_pair,
-                                   interval=interval)
-                candles_df.index = pd.to_datetime(candles_df.timestamp, unit='s')
+                    return Candles(
+                        candles_df=pd.DataFrame(), connector_name=connector_name, trading_pair=trading_pair, interval=interval
+                    )
+                candles_df.index = pd.to_datetime(candles_df.timestamp, unit="s")
 
             if cache_key in self._candles_cache:
-                self._candles_cache[cache_key] = pd.concat(
-                    [self._candles_cache[cache_key], candles_df]).drop_duplicates(keep='first').sort_index()
+                self._candles_cache[cache_key] = (
+                    pd.concat([self._candles_cache[cache_key], candles_df]).drop_duplicates(keep="first").sort_index()
+                )
             else:
                 self._candles_cache[cache_key] = candles_df
 
-            return Candles(candles_df=self._candles_cache[cache_key][
-                (self._candles_cache[cache_key].index >= pd.to_datetime(start_time, unit='s')) &
-                (self._candles_cache[cache_key].index <= pd.to_datetime(end_time, unit='s'))],
-                           connector_name=connector_name, trading_pair=trading_pair, interval=interval)
+            return Candles(
+                candles_df=self._candles_cache[cache_key][
+                    (self._candles_cache[cache_key].index >= pd.to_datetime(start_time, unit="s"))
+                    & (self._candles_cache[cache_key].index <= pd.to_datetime(end_time, unit="s"))
+                ],
+                connector_name=connector_name,
+                trading_pair=trading_pair,
+                interval=interval,
+            )
         except Exception as e:
             logger.error(f"Error fetching candles for {connector_name} {trading_pair} {interval}: {type(e).__name__} - {e}")
             raise
 
-    async def get_candles_last_days(self,
-                                    connector_name: str,
-                                    trading_pair: str,
-                                    interval: str,
-                                    days: int,
-                                    from_trades: bool = False) -> Candles:
+    async def get_candles_last_days(
+        self, connector_name: str, trading_pair: str, interval: str, days: int, from_trades: bool = False
+    ) -> Candles:
         end_time = int(time.time())
         start_time = end_time - days * 24 * 60 * 60
         return await self.get_candles(connector_name, trading_pair, interval, start_time, end_time, from_trades)
 
-    async def get_candles_batch_last_days(self, connector_name: str, trading_pairs: List, interval: str,
-                                          days: int, batch_size: int = 10, sleep_time: float = 2.0):
+    async def get_candles_batch_last_days(
+        self, connector_name: str, trading_pairs: List, interval: str, days: int, batch_size: int = 10, sleep_time: float = 2.0
+    ):
         number_of_calls = (len(trading_pairs) // batch_size) + 1
 
         all_candles = []
@@ -174,12 +245,15 @@ class CLOBDataSource:
             end = min(end, len(trading_pairs))
             trading_pairs_batch = trading_pairs[start:end]
 
-            tasks = [self.get_candles_last_days(
-                connector_name=connector_name,
-                trading_pair=trading_pair,
-                interval=interval,
-                days=days,
-            ) for trading_pair in trading_pairs_batch]
+            tasks = [
+                self.get_candles_last_days(
+                    connector_name=connector_name,
+                    trading_pair=trading_pair,
+                    interval=interval,
+                    days=days,
+                )
+                for trading_pair in trading_pairs_batch
+            ]
 
             candles = await asyncio.gather(*tasks)
             all_candles.extend(candles)
@@ -218,12 +292,7 @@ class CLOBDataSource:
         for key, df in self._candles_cache.items():
             candles_path = os.path.join(root_path, "data", "candles")
             filename = os.path.join(candles_path, f"{key[0]}|{key[1]}|{key[2]}.parquet")
-            df.to_parquet(
-                filename,
-                engine='pyarrow',
-                compression='snappy',
-                index=True
-            )
+            df.to_parquet(filename, engine="pyarrow", compression="snappy", index=True)
 
         logger.info("Candles cache dumped")
 
@@ -240,10 +309,19 @@ class CLOBDataSource:
             try:
                 connector_name, trading_pair, interval = file.split(".")[0].split("|")
                 candles = pd.read_parquet(os.path.join(candles_path, file))
-                candles.index = pd.to_datetime(candles.timestamp, unit='s')
+                candles.index = pd.to_datetime(candles.timestamp, unit="s")
                 candles.index.name = None
-                columns = ['open', 'high', 'low', 'close', 'volume', 'quote_asset_volume',
-                           'n_trades', 'taker_buy_base_volume', 'taker_buy_quote_volume']
+                columns = [
+                    "open",
+                    "high",
+                    "low",
+                    "close",
+                    "volume",
+                    "quote_asset_volume",
+                    "n_trades",
+                    "taker_buy_base_volume",
+                    "taker_buy_quote_volume",
+                ]
                 for column in columns:
                     candles[column] = pd.to_numeric(candles[column])
 
@@ -251,39 +329,34 @@ class CLOBDataSource:
             except Exception as e:
                 logger.error(f"Error loading {file}: {type(e).__name__} - {e}")
 
-    async def get_trades(self, connector_name: str, trading_pair: str, start_time: int, end_time: int,
-                         from_id: Optional[int] = None):
-        return await self.trades_feeds[connector_name].get_historical_trades(trading_pair, start_time, end_time,
-                                                                             from_id)
+    async def get_trades(
+        self, connector_name: str, trading_pair: str, start_time: int, end_time: int, from_id: Optional[int] = None
+    ):
+        return await self.trades_feeds[connector_name].get_historical_trades(trading_pair, start_time, end_time, from_id)
 
     @staticmethod
     def convert_interval_to_pandas_freq(interval: str) -> str:
         """
         Converts a candle interval string to a pandas frequency string.
         """
-        return INTERVAL_MAPPING.get(interval, 'T')
+        return INTERVAL_MAPPING.get(interval, "T")
 
-    async def get_funding_rate_history(self, 
-                                     symbol: str, 
-                                     start_time: Optional[int] = None,
-                                     end_time: Optional[int] = None,
-                                     limit: int = 1000) -> pd.DataFrame:
+    async def get_funding_rate_history(
+        self, symbol: str, start_time: Optional[int] = None, end_time: Optional[int] = None, limit: int = 1000
+    ) -> pd.DataFrame:
         """Get historical funding rates for a symbol"""
         connector = self.connectors.get("binance_perpetual")
         params = {"symbol": symbol, "limit": limit}
-        
+
         if start_time:
             params["startTime"] = start_time
         if end_time:
             params["endTime"] = end_time
 
         response = await connector._api_get(
-            path_url="/fapi/v1/fundingRate",
-            params=params,
-            is_auth_required=False,
-            limit_id="REQUEST_WEIGHT"
+            path_url="/fapi/v1/fundingRate", params=params, is_auth_required=False, limit_id="REQUEST_WEIGHT"
         )
-        
+
         df = pd.DataFrame(response)
         if not df.empty:
             df["fundingTime"] = pd.to_datetime(df["fundingTime"], unit="ms")
@@ -303,15 +376,11 @@ class CLOBDataSource:
         # Get historical data for last 72 hours
         end_time = int(datetime.now().timestamp() * 1000)
         start_time = int((datetime.now() - timedelta(hours=72)).timestamp() * 1000)
-        
-        historical_rates = await self.get_funding_rate_history(
-            symbol=symbol,
-            start_time=start_time,
-            end_time=end_time
-        )
-        
+
+        historical_rates = await self.get_funding_rate_history(symbol=symbol, start_time=start_time, end_time=end_time)
+
         current_info = await self.get_current_funding_info(symbol)
-        
+
         if historical_rates.empty:
             return {}
 
@@ -323,7 +392,7 @@ class CLOBDataSource:
             "avg_funding_24h": float(historical_rates.tail(8)["fundingRate"].mean()),  # 8 funding intervals = 24h
             "avg_funding_72h": float(historical_rates["fundingRate"].mean()),
             "funding_history": historical_rates.reset_index().to_dict(orient="records"),
-            "updated_at": datetime.now()
+            "updated_at": datetime.now(),
         }
-        
+
         return metrics

--- a/nexus/history/binance-futures/README.md
+++ b/nexus/history/binance-futures/README.md
@@ -1,0 +1,1 @@
+Place parquet files here

--- a/nexus/notebooks/local_pmm_simple_backtest.py
+++ b/nexus/notebooks/local_pmm_simple_backtest.py
@@ -1,0 +1,56 @@
+import asyncio
+import datetime
+import os
+import sys
+from decimal import Decimal
+
+root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))  # noqa: E402
+sys.path.append(root_path)  # noqa: E402
+
+from hummingbot.strategy_v2.executors.position_executor.data_types import TrailingStop  # noqa: E402
+from hummingbot.strategy_v2.utils.distributions import Distributions  # noqa: E402
+
+from controllers.market_making.pmm_simple import PMMSimpleConfig  # noqa: E402
+from core.backtesting import BacktestingEngine  # noqa: E402
+from core.data_sources.clob import CLOBDataSource  # noqa: E402
+
+# Load local dataset
+local_data_path = os.path.join(root_path, "nexus", "history", "binance-futures")
+clob = CLOBDataSource(local_data_path=local_data_path)
+
+backtesting = BacktestingEngine(load_cached_data=False)
+
+# Preload candles from local file
+clob._load_local_dataset("binance_perpetual", "BTCUSDT", "1m")
+backtesting._bt_engine.backtesting_data_provider.candles_feeds["binance_perpetual_BTCUSDT_1m"] = clob.candles_cache[
+    ("binance_perpetual", "BTCUSDT", "1m")
+].candles_df
+bt_data = backtesting._bt_engine.backtesting_data_provider.candles_feeds["binance_perpetual_BTCUSDT_1m"]
+backtesting._bt_engine.backtesting_data_provider.start_time = bt_data["timestamp"].min()
+backtesting._bt_engine.backtesting_data_provider.end_time = bt_data["timestamp"].max()
+
+config = PMMSimpleConfig(
+    connector_name="binance_perpetual",
+    trading_pair="BTCUSDT",
+    sell_spreads=Distributions.arithmetic(3, 0.002, 0.001),
+    buy_spreads=Distributions.arithmetic(3, 0.002, 0.001),
+    total_amount_quote=Decimal("1000"),
+    take_profit=Decimal("0.003"),
+    stop_loss=Decimal("0.003"),
+    trailing_stop=TrailingStop(activation_price=Decimal("0.001"), trailing_delta=Decimal("0.0005")),
+    time_limit=60 * 60,
+    cooldown_time=60 * 60,
+    executor_refresh_time=60,
+)
+
+start = int(datetime.datetime(2024, 1, 1).timestamp())
+end = int(datetime.datetime(2024, 1, 2).timestamp())
+
+
+async def main():
+    result = await backtesting.run_backtesting(config, start, end, "1m")
+    print(result.get_results_summary())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- enable injecting local parquet data into `CLOBDataSource`
- create example script for PMM backtest with BTCUSDT 1m dataset
- ignore local dataset files

## Testing
- `pre-commit run --files nexus/notebooks/local_pmm_simple_backtest.py core/data_sources/clob.py`

------
https://chatgpt.com/codex/tasks/task_e_688897a6c1f483268f3e267350185324